### PR TITLE
ST3 compatibility of the getting start example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,10 @@ Then, write your tests:
             # `run` will be run inside Sublime Text. Perform your assertions etc there.
             return """
     # Use ScratchView utility provided by `sublime_plugin_tests`
-    from utils.scratch_view import ScratchView
+    try:
+      from utils.scratch_view import ScratchView
+    except ImportError:
+      from .utils.scratch_view import ScratchView
 
     def run():
       # Generate new scratch file


### PR DESCRIPTION
When I was trying the "getting start" example in ST3 , I kept encountering error

```
======================================================================
FAIL: test_left_delete_single (a_test.TestLeft)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/sublime_plugin_tests/framework.py", line 45, in wrapped_fn
    self.assertTrue(success, failure_reason)
AssertionError: Traceback (most recent call last):
  File "/home/vagrant/.config/sublime-text-3/Packages/sublime-harness-tmp/plugin.py", line 48, in run
    plugin_dict['run']()
KeyError: 'run'
```

I spent quite some time to realize the problem is related to the `import` statement.
